### PR TITLE
Fix non-breakable space and stop click event propagation

### DIFF
--- a/src/copy-code-widget.ts
+++ b/src/copy-code-widget.ts
@@ -7,7 +7,7 @@ export class CopyWidget extends WidgetType {
     }
 
   toDOM(view: EditorView): HTMLElement {
-    const icon = createSpan({cls: "copy-to-clipboard-icon", text: " 📋"})
+    const icon = createSpan({cls: "copy-to-clipboard-icon", text: "\xa0📋"})
 
     icon.onclick = (event) => {
         const element = (event.target as HTMLElement)

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,8 +16,9 @@ export default class CopyInlineCodePlugin extends Plugin {
 				const icon = createSpan({cls: "copy-to-clipboard-icon", text: "\xa0📋"})
 				const textToCopy = code.textContent
 
-				icon.onclick = () => {			
+				icon.onclick = (event) => {			
 					if(textToCopy) {
+						event.stopPropagation();
 						navigator.clipboard.writeText(textToCopy)
 						new Notice(`Copied '${textToCopy}' to clipboard!`);
 					}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ export default class CopyInlineCodePlugin extends Plugin {
 					return
 				}
 
-				const icon = createSpan({cls: "copy-to-clipboard-icon", text: " 📋"})
+				const icon = createSpan({cls: "copy-to-clipboard-icon", text: "\xa0📋"})
 				const textToCopy = code.textContent
 
 				icon.onclick = () => {			


### PR DESCRIPTION
Keeps the 📋 emoji on the same line as inline code element. It looks better in table that has longer cells.

Also when 📋 is clicked, it won't propagate the click event. For example, when using Advanced Tables, copy click would take you to their edit table functionality and it was quite annoying because of shifting widths).

<img width="824" alt="broken" src="https://github.com/Alddar/obsidian-copy-inline-code-plugin/assets/20018/f9ef302c-0719-4a9c-8349-abec64425d6d">
<img width="824" alt="fixed" src="https://github.com/Alddar/obsidian-copy-inline-code-plugin/assets/20018/fe00f727-f949-4577-a090-23b7748177cf">
