### PR TITLE
Refactor copy-code-widget.ts for improved functionality

### DIFF
--- a/src/copy-code-widget.ts
+++ b/src/copy-code-widget.ts
@@ -16,7 +16,7 @@ export class CopyWidget extends WidgetType {
           previousElement = previousElement.previousElementSibling
         }
 
-        const textToCopy = previousElement?.innerHTML
+        const textToCopy = previousElement?.textContent
         if(textToCopy) {
             navigator.clipboard.writeText(textToCopy)
             new Notice(`Copied '${textToCopy}' to clipboard!`);


### PR DESCRIPTION
- Changed `innerHTML` to `textContent` for more accurate text copying
- Fixes bug where characters were being copied as HTML character name codes
- Example characters that were broken and what they were being copied as:
```
< = &lt;
> = &gt;
& = &amp;
```